### PR TITLE
chore(CODEOWNERS): create file, add DataViz

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @grafana/dataviz-squad


### PR DESCRIPTION
🆕 This change adds the @grafana/dataviz-squad as owners of this repo, so we will be automagically tagged as PR reviewers etc.

`CODEOWNERS` [files can be located in a few places](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location) -- I've followed the [practice used in the @grafana/grafana repo](https://github.com/grafana/grafana/blob/main/.github/CODEOWNERS) by putting it under `.github/CODEOWNERS` for consistency.